### PR TITLE
Added tablet nav bar

### DIFF
--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -17,7 +17,6 @@ const depegEnabled = import.meta.env.VITE_FF_DEPEG_WARNING === "true"
 const settingsEanbled = import.meta.env.VITE_FF_SETTINGS_ENABLED === "true"
 
 export const Header = () => {
-  const isDesktop = useMedia(theme.viewport.gte.sm)
   const isMediumMedia = useMedia(theme.viewport.lt.md)
   const { t } = useTranslation()
 
@@ -43,30 +42,30 @@ export const Header = () => {
           <div sx={{ flex: "row", align: "center" }}>
             <Icon
               sx={{ color: "white" }}
-              icon={
-                isDesktop && !isMediumMedia ? <HydraLogoFull /> : <HydraLogo />
-              }
+              icon={!isMediumMedia ? <HydraLogoFull /> : <HydraLogo />}
             />
-            {isDesktop && <HeaderMenu />}
+            {!isMediumMedia && <HeaderMenu />}
           </div>
           <div sx={{ flex: "row", align: "center", gap: [12, 24] }}>
             <div sx={{ flex: "row" }}>
-              <InfoTooltip
-                text={t("header.documentation.tooltip")}
-                type="black"
-              >
-                <a
-                  href="https://docs.hydradx.io/"
-                  target="blank"
-                  rel="noreferrer"
+              {!isMediumMedia && (
+                <InfoTooltip
+                  text={t("header.documentation.tooltip")}
+                  type="black"
                 >
-                  <SQuestionmark />
-                </a>
-              </InfoTooltip>
+                  <a
+                    href="https://docs.hydradx.io/"
+                    target="blank"
+                    rel="noreferrer"
+                  >
+                    <SQuestionmark />
+                  </a>
+                </InfoTooltip>
+              )}
               <Bell />
             </div>
             <WalletConnectButton />
-            {isDesktop && settingsEanbled && <HeaderSettings />}
+            {!isMediumMedia && settingsEanbled && <HeaderSettings />}
           </div>
         </div>
       </SHeader>

--- a/src/components/Layout/Header/MobileNavBar/MobileNavBar.styled.ts
+++ b/src/components/Layout/Header/MobileNavBar/MobileNavBar.styled.ts
@@ -26,6 +26,10 @@ export const SMobileNavBar = styled.div`
   backdrop-filter: blur(12px);
 
   @media ${theme.viewport.gte.sm} {
+    display: flex;
+  }
+
+  @media ${theme.viewport.gte.md} {
     display: none;
   }
 `
@@ -42,6 +46,8 @@ export const SNavBarItem = styled.span<{ active?: boolean }>`
   font-size: 12px;
 
   height: 100%;
+  width: 60px;
+  margin: 0 17px;
 
   color: ${({ active }) =>
     active ? theme.colors.brightBlue300 : theme.colors.basic400};

--- a/src/components/Layout/Header/MobileNavBar/MobileNavBar.styled.ts
+++ b/src/components/Layout/Header/MobileNavBar/MobileNavBar.styled.ts
@@ -50,7 +50,7 @@ export const SNavBarItem = styled.span<{ active?: boolean }>`
   margin: 0 17px;
 
   color: ${({ active }) =>
-    active ? theme.colors.brightBlue300 : theme.colors.basic400};
+    active ? theme.colors.brightBlue300 : theme.colors.white};
 
   ${({ active }) =>
     active &&

--- a/src/components/Layout/Header/MobileNavBar/MobileNavBar.tsx
+++ b/src/components/Layout/Header/MobileNavBar/MobileNavBar.tsx
@@ -10,6 +10,8 @@ import {
   SNavBarItemHidden,
 } from "./MobileNavBar.styled"
 import { MoreButton } from "./MoreButton"
+import { useMedia } from "react-use"
+import { theme } from "theme"
 
 export const MobileNavBarItem = ({
   item,
@@ -31,12 +33,13 @@ export const MobileNavBarItem = ({
 export const MobileNavBar = () => {
   const { t } = useTranslation()
   const { account } = useSearch()
+  const isMediumMedia = useMedia(theme.viewport.gte.sm)
 
   const [visibleTabs, hiddenTabs] = MENU_ITEMS.filter(
     (item) => item.enabled,
   ).reduce(
     (result, value) => {
-      const isVisible = value.mobVisible
+      const isVisible = isMediumMedia ? value.tabVisible : value.mobVisible
       result[isVisible ? 0 : 1].push(value)
       return result
     },

--- a/src/components/Layout/Header/MobileNavBar/MoreButton.tsx
+++ b/src/components/Layout/Header/MobileNavBar/MoreButton.tsx
@@ -20,7 +20,7 @@ export const MoreButton = ({ tabs }: MoreButtonProps) => {
 
   return (
     <>
-      <STabButton active={openModal} onClick={() => setOpenModal(true)}>
+      <STabButton active={openModal} onClick={() => setOpenModal(!openModal)}>
         <Icon size={20} icon={<MoreTabIcon />} />
         {t("header.more")}
       </STabButton>

--- a/src/components/Layout/Header/MobileNavBar/MoreButton.tsx
+++ b/src/components/Layout/Header/MobileNavBar/MoreButton.tsx
@@ -1,11 +1,14 @@
 import { ReactComponent as MoreTabIcon } from "assets/icons/MoreTabIcon.svg"
 import { Icon } from "components/Icon/Icon"
-import { Spacer } from "components/Spacer/Spacer"
 import { ReactNode, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { HeaderSettingsMobile } from "../settings/mobile/HeaderSettingsMobile"
 import { STabButton } from "./MobileNavBar.styled"
 import { TabMenuModal } from "./TabMenuModal/TabMenuModal"
+import { SQuestionmark } from "components/Layout/Header/Header.styled"
+import { Separator } from "components/Separator/Separator"
+import { Text } from "components/Typography/Text/Text"
+import { theme } from "theme"
 
 const settingsEanbled = import.meta.env.VITE_FF_SETTINGS_ENABLED === "true"
 
@@ -22,14 +25,46 @@ export const MoreButton = ({ tabs }: MoreButtonProps) => {
         {t("header.more")}
       </STabButton>
       <TabMenuModal open={openModal} onClose={() => setOpenModal(false)}>
-        <div sx={{ flex: "column", color: "white", px: 12, pb: 12, gap: 8 }}>
-          {settingsEanbled && (
-            <>
-              <Spacer size={4} />
-              <HeaderSettingsMobile />
-              <Spacer size={14} />
-            </>
-          )}
+        <div sx={{ flex: "column", color: "white", p: "8px 12px", gap: 8 }}>
+          <div
+            sx={{
+              flex: "row",
+              justify: "space-between",
+              width: "calc(100% - 20px)",
+            }}
+          >
+            {settingsEanbled && (
+              <>
+                <HeaderSettingsMobile />
+                <Separator
+                  orientation="vertical"
+                  css={{ background: "rgba(158, 167, 186, 0.06)" }}
+                />
+              </>
+            )}
+            <a
+              href="https://docs.hydradx.io/"
+              target="blank"
+              rel="noreferrer"
+              sx={{ flex: "row", align: "center", gap: 10, py: 10 }}
+            >
+              <SQuestionmark
+                sx={{
+                  width: 34,
+                  height: 34,
+                  flex: "row",
+                  align: "center",
+                }}
+                css={{
+                  borderRadius: "9999px",
+                  background: `rgba(${theme.rgbColors.darkBlue401}, 0.8)`,
+                }}
+              />
+              <Text fs={12} color="brightBlue200">
+                Docs
+              </Text>
+            </a>
+          </div>
           {tabs}
         </div>
       </TabMenuModal>

--- a/src/components/Layout/Header/MobileNavBar/TabMenuModal/TabMenuModal.styled.ts
+++ b/src/components/Layout/Header/MobileNavBar/TabMenuModal/TabMenuModal.styled.ts
@@ -1,9 +1,9 @@
 import styled from "@emotion/styled"
-import { DialogContent } from "@radix-ui/react-dialog"
 import { IconButton } from "components/IconButton/IconButton"
+import { motion } from "framer-motion"
 import { theme } from "theme"
 
-export const SModalContent = styled(DialogContent)`
+export const SModalContent = styled(motion.div)`
   position: absolute;
   right: 0;
   bottom: 0;
@@ -25,7 +25,7 @@ export const SModalContent = styled(DialogContent)`
   }
 `
 
-export const SBackdrop = styled.div`
+export const SBackdrop = styled(motion.div)`
   width: 100%;
   height: 100vh;
 

--- a/src/components/Layout/Header/MobileNavBar/TabMenuModal/TabMenuModal.styled.ts
+++ b/src/components/Layout/Header/MobileNavBar/TabMenuModal/TabMenuModal.styled.ts
@@ -9,9 +9,9 @@ export const SModalContent = styled(DialogContent)`
   bottom: 0;
 
   width: 70%;
+  max-width: 300px;
 
   margin: 20px 17px 1px 0;
-  padding-top: 20px;
   outline: 1px solid rgba(48, 52, 76, 0.5);
 
   border-radius: 4px;
@@ -42,8 +42,8 @@ export const CloseButton = styled(IconButton)`
   background: ${theme.colors.darkBlue700};
 
   position: absolute;
-  top: -10px;
-  right: -10px;
+  top: -16px;
+  right: -8px;
 
   :focus-visible {
     outline: none;

--- a/src/components/Layout/Header/MobileNavBar/TabMenuModal/TabMenuModal.tsx
+++ b/src/components/Layout/Header/MobileNavBar/TabMenuModal/TabMenuModal.tsx
@@ -1,9 +1,10 @@
-import { Dialog, DialogPortal } from "@radix-ui/react-dialog"
+import { Dialog, DialogPortal, DialogContent } from "@radix-ui/react-dialog"
 import { PropsWithChildren } from "react"
 import { RemoveScroll } from "react-remove-scroll"
 import { ReactComponent as CrossIcon } from "assets/icons/CrossIcon.svg"
-import { CloseButton, SBackdrop, SModalContent } from "./TabMenuModal.styled"
+import { CloseButton, SModalContent, SBackdrop } from "./TabMenuModal.styled"
 import { useTranslation } from "react-i18next"
+import { AnimatePresence } from "framer-motion"
 
 type TabMenuModalProps = {
   open: boolean
@@ -18,18 +19,38 @@ export const TabMenuModal = ({
   const { t } = useTranslation()
   return (
     <Dialog open={open}>
-      <DialogPortal>
-        <SBackdrop>
-          <SModalContent>
-            <CloseButton
-              icon={<CrossIcon />}
-              onClick={onClose}
-              name={t("modal.closeButton.name")}
-            />
-            <RemoveScroll enabled={open}>{children}</RemoveScroll>
-          </SModalContent>
-        </SBackdrop>
-      </DialogPortal>
+      <AnimatePresence mode="wait">
+        {open && (
+          <DialogPortal forceMount>
+            <SBackdrop
+              key="backdrop"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2 }}
+            >
+              <DialogContent onInteractOutside={onClose} asChild>
+                <SModalContent
+                  key="content"
+                  initial={{ opacity: 0, x: 200 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: 200 }}
+                  transition={{
+                    duration: 0.2,
+                  }}
+                >
+                  <CloseButton
+                    icon={<CrossIcon />}
+                    onClick={onClose}
+                    name={t("modal.closeButton.name")}
+                  />
+                  <RemoveScroll enabled={open}>{children}</RemoveScroll>
+                </SModalContent>
+              </DialogContent>
+            </SBackdrop>
+          </DialogPortal>
+        )}
+      </AnimatePresence>
     </Dialog>
   )
 }

--- a/src/components/Layout/Header/menu/HeaderSubMenu.tsx
+++ b/src/components/Layout/Header/menu/HeaderSubMenu.tsx
@@ -24,7 +24,7 @@ export const HeaderSubMenu = ({ item }: Props) => {
   const { account } = useSearch()
   const [open, setOpen] = useState(false)
 
-  const isDesktop = useMedia(theme.viewport.gte.sm)
+  const isDesktop = useMedia(theme.viewport.gte.md)
   const match = useMatchRoute()
 
   const { key, subItems } = item

--- a/src/components/Layout/Header/settings/HeaderSettings.styled.ts
+++ b/src/components/Layout/Header/settings/HeaderSettings.styled.ts
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled"
-import { Content, Trigger } from "@radix-ui/react-dropdown-menu"
+import { Trigger } from "@radix-ui/react-dropdown-menu"
 import { ButtonTransparent } from "components/Button/Button"
+import { motion } from "framer-motion"
 import { theme } from "theme"
 
 export const SButton = styled(Trigger)`
@@ -32,7 +33,7 @@ export const SHeader = styled.div`
   padding: 14px 21px;
 `
 
-export const SContent = styled(Content)`
+export const SContent = styled(motion.div)`
   --modal-header-padding-y: 14px;
   --modal-header-padding-x: 20px;
   --modal-header-btn-size: 26px;

--- a/src/components/Layout/Header/settings/HeaderSettings.tsx
+++ b/src/components/Layout/Header/settings/HeaderSettings.tsx
@@ -1,4 +1,4 @@
-import { Portal, Root } from "@radix-ui/react-dropdown-menu"
+import { Portal, Root, Content } from "@radix-ui/react-dropdown-menu"
 import { ReactComponent as IconArrow } from "assets/icons/IconArrow.svg"
 import { ReactComponent as IconDollar } from "assets/icons/IconDollarLarge.svg"
 import { ReactComponent as IconSettings } from "assets/icons/IconSettings.svg"
@@ -9,6 +9,7 @@ import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { SButton, SContent, SItem, SItems } from "./HeaderSettings.styled"
 import { HeaderSettingsDisplayAsset } from "./displayAsset/HeaderSettingsDisplayAsset"
+import { AnimatePresence } from "framer-motion"
 
 export const HeaderSettings = () => {
   const [open, setOpen] = useState(false)
@@ -20,12 +21,28 @@ export const HeaderSettings = () => {
       <SButton>
         <IconSettings />
       </SButton>
-
-      <Portal>
-        <SContent align="end" sideOffset={8}>
-          <HeaderSettingsContents onClose={onClose} />
-        </SContent>
-      </Portal>
+      <AnimatePresence>
+        {open && (
+          <Portal forceMount>
+            <Content align="end" sideOffset={18}>
+              <SContent
+                initial={{ opacity: 0, height: 50, x: 200 }}
+                animate={{ opacity: 1, height: "auto", x: 0 }}
+                exit={{ opacity: 0, height: 50, x: 200 }}
+                transition={{
+                  type: "spring",
+                  mass: 1,
+                  stiffness: 300,
+                  damping: 20,
+                  duration: 0.2,
+                }}
+              >
+                <HeaderSettingsContents onClose={onClose} />
+              </SContent>
+            </Content>
+          </Portal>
+        )}
+      </AnimatePresence>
     </Root>
   )
 }

--- a/src/components/Layout/Header/settings/mobile/HeaderSettingsMobile.tsx
+++ b/src/components/Layout/Header/settings/mobile/HeaderSettingsMobile.tsx
@@ -5,6 +5,7 @@ import { Text } from "components/Typography/Text/Text"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { HeaderSettingsContents } from "../HeaderSettings"
+import { theme } from "theme"
 
 export const HeaderSettingsMobile = () => {
   const { t } = useTranslation()
@@ -14,9 +15,14 @@ export const HeaderSettingsMobile = () => {
     <>
       <div sx={{ flex: "row", align: "center", gap: 10 }}>
         <IconButton
+          size={34}
           onClick={() => setOpen(true)}
           icon={<IconSettings />}
-          sx={{ color: "brightBlue100" }}
+          css={{
+            border: "none",
+            color: theme.colors.brightBlue100,
+            background: `rgba(${theme.rgbColors.darkBlue401}, 0.8)`,
+          }}
           round
         />
         <Text fs={12} fw={500} color="brightBlue200">

--- a/src/components/Layout/Page/Page.styled.ts
+++ b/src/components/Layout/Page/Page.styled.ts
@@ -62,12 +62,19 @@ export const SPageContent = styled.main`
   @media ${theme.viewport.gte.sm} {
     padding: 0 20px;
     padding-top: var(--nav-height);
+    padding-bottom: var(--mobile-nav-height);
 
     display: block;
 
     ::-webkit-scrollbar {
       width: 6px;
     }
+  }
+
+  @media ${theme.viewport.gte.md} {
+    padding-bottom: 0;
+
+    display: block;
   }
 `
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -136,7 +136,7 @@ const zIndices = {
 const breakpoints = {
   xs: 480,
   sm: 768,
-  md: 1024,
+  md: 1200, //value represents navigation bar for tablet
   lg: 1440,
   xl: 1536,
 } as const

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -5,6 +5,8 @@ import { ReactComponent as WalletIcon } from "assets/icons/Wallet.svg"
 import { ReactComponent as IconDCA } from "assets/icons/navigation/IconDCA.svg"
 import { ReactComponent as IconOTC } from "assets/icons/navigation/IconOTC.svg"
 import { ReactComponent as IconSwap } from "assets/icons/navigation/IconSwap.svg"
+import { ReactComponent as StatsIcon } from "assets/icons/ChartIcon.svg"
+import { ReactComponent as StakingIcon } from "assets/icons/StakingIcon.svg"
 
 export const LINKS = {
   home: "/",
@@ -47,7 +49,8 @@ export const MENU_ITEMS = [
     enabled: true,
     external: false,
     mobVisible: true,
-    mobOrder: 0,
+    tabVisible: true,
+    mobOrder: 1,
   },
   {
     key: "liquidity",
@@ -57,6 +60,7 @@ export const MENU_ITEMS = [
     enabled: isPoolsPageEnabled,
     external: false,
     mobVisible: true,
+    tabVisible: true,
     mobOrder: 2,
   },
   {
@@ -67,7 +71,8 @@ export const MENU_ITEMS = [
     enabled: true,
     external: false,
     mobVisible: true,
-    mobOrder: 1,
+    tabVisible: true,
+    mobOrder: 0,
   },
   {
     key: "xcm",
@@ -77,26 +82,29 @@ export const MENU_ITEMS = [
     enabled: isXcmPageEnabled,
     external: false,
     mobVisible: false,
-    mobOrder: 3,
+    tabVisible: false,
+    mobOrder: 5,
   },
   {
     key: "stats",
     href: LINKS.stats,
-    Icon: TransferIcon,
+    Icon: StatsIcon,
     subItems: undefined,
     enabled: isStatsEnabled,
     external: false,
     mobVisible: false,
-    mobOrder: 4,
+    tabVisible: true,
+    mobOrder: 3,
   },
   {
     key: "staking",
     href: LINKS.staking,
-    Icon: TransferIcon,
+    Icon: StakingIcon,
     subItems: undefined,
     enabled: isStakingEnabled,
     external: false,
     mobVisible: false,
+    tabVisible: true,
     mobOrder: 4,
   },
 ] as const


### PR DESCRIPTION
Added navigation bar for the tablet view, since tabs on the main nav bar don't fit he width of the header
Added icons for the Stats and Staking pages
Added animation dor the Settings and additional tabs modals
https://www.figma.com/file/eqzR2azTracqA8Vv0y4GUv/%F0%9F%96%A5--Hydra-%7C-Desktop-Library?node-id=23620%3A205473&mode=dev
https://www.figma.com/file/bAiwRCwvONOLUx2YGJOSfe/%F0%9F%93%B1-Hydra-%7C-Mobile-UI?node-id=14583%3A122716&mode=dev