### PR TITLE
add Dotters GeoDNS as a provider

### DIFF
--- a/src/api/provider.ts
+++ b/src/api/provider.ts
@@ -30,6 +30,13 @@ export const PROVIDERS = [
     env: "production",
   },
   {
+    name: "Mainnet via Dotters(GeoDNS)",
+    url: "wss://hydradx.paras.dotters.network/hydradx",
+    indexerUrl: "https://hydradx-explorer.play.hydration.cloud/graphql",
+    squidUrl: "https://hydra-data-squid.play.hydration.cloud/graphql",
+    env: "production",
+  },
+  {
     name: "Rococo via GC",
     url: "wss://hydradx-rococo-rpc.play.hydration.cloud",
     indexerUrl: "https://hydradx-rococo-explorer.play.hydration.cloud/graphql",


### PR DESCRIPTION
 https://polkadot.js.org/apps/?rpc=wss://hydradx.paras.dotters.network#/explorer
 https://hydradx.rotko.net/
 
 should provide quite nice world wide latencies for the frontend. for sub0 in bkk latencies should be sub10ms(hosted within 20km).
 
 